### PR TITLE
New release 1.3: Fix newline bug

### DIFF
--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 0d05f52c00a64cb2b2bea68744f6316c
 ExtensionType: 2
 Name: Copy Request Response
 RepoName: copy-request-response
-ScreenVersion: 1.1
-SerialVersion: 4
+ScreenVersion: 1.2
+SerialVersion: 5
 MinPlatformVersion: 0
 ProOnly: False
 Author: Emanuel Duss / Compass Security

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -2,8 +2,8 @@ Uuid: 0d05f52c00a64cb2b2bea68744f6316c
 ExtensionType: 2
 Name: Copy Request Response
 RepoName: copy-request-response
-ScreenVersion: 1.2
-SerialVersion: 5
+ScreenVersion: 1.3
+SerialVersion: 7
 MinPlatformVersion: 0
 ProOnly: False
 Author: Emanuel Duss / Compass Security

--- a/CopyRequestResponse.py
+++ b/CopyRequestResponse.py
@@ -83,7 +83,7 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         data.extend(self.str_to_array(self.CUT_TEXT))
 
         # Ugly hack because VMware is messing up the clipboard if a text is still selected, the function
-        # has to be run in a separate thread which sleeps for 2 seconds.
+        # has to be run in a separate thread which sleeps for 1.5 seconds.
         t = threading.Thread(target=self.copyToClipboard, args=(data,True))
         t.start()
 

--- a/CopyRequestResponse.py
+++ b/CopyRequestResponse.py
@@ -12,7 +12,10 @@ import time
 
 class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
 
-    CUT_TEXT = [ord(c) for c in "[...]"]
+    CUT_TEXT = "[...]"
+
+    def str_to_array(self, string):
+        return [ord(c) for c in string]
 
     def registerExtenderCallbacks(self, callbacks):
         callbacks.setExtensionName("Copy HTTP Request & Response")
@@ -54,7 +57,7 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         httpResponseBodyOffset = self.helpers.analyzeResponse(httpResponse).getBodyOffset()
 
         data = httpRequest + httpResponse[0:httpResponseBodyOffset]
-        data.extend(self.CUT_TEXT)
+        data.extend(self.str_to_array(self.CUT_TEXT))
 
         self.copyToClipboard(data)
 
@@ -67,11 +70,11 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         httpResponseData = httpResponse[selectionBounds[0]:selectionBounds[1]]
 
         data = httpRequest + httpResponse[0:httpResponseBodyOffset]
-        data.extend(self.CUT_TEXT)
         data.append(13) # Line Break
+        data.extend(self.str_to_array(self.CUT_TEXT))
         data.extend(httpResponseData)
         data.append(13)
-        data.extend(self.CUT_TEXT)
+        data.extend(self.str_to_array(self.CUT_TEXT))
 
         # Ugly hack because VMware is messing up the clipboard if a text is still selected, the function
         # has to be run in a separate thread which sleeps for 2 seconds.

--- a/CopyRequestResponse.py
+++ b/CopyRequestResponse.py
@@ -46,9 +46,10 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         httpRequest = httpTraffic.getRequest()
         httpResponse = httpTraffic.getResponse()
 
-        data = httpRequest
+        data = self.stripTrailingNewlines(httpRequest)
         data.append(13) # Line Break
-        data.extend(httpResponse)
+        data.append(13)
+        data.extend(self.stripTrailingNewlines(httpResponse))
 
         self.copyToClipboard(data)
 
@@ -58,7 +59,8 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         httpResponse = httpTraffic.getResponse()
         httpResponseBodyOffset = self.helpers.analyzeResponse(httpResponse).getBodyOffset()
 
-        data = httpRequest
+        data = self.stripTrailingNewlines(httpRequest)
+        data.append(13)
         data.append(13)
         data.extend(httpResponse[0:httpResponseBodyOffset])
         data.extend(self.str_to_array(self.CUT_TEXT))
@@ -73,12 +75,13 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         selectionBounds = self.context.getSelectionBounds()
         httpResponseData = httpResponse[selectionBounds[0]:selectionBounds[1]]
 
-        data = httpRequest
+        data = self.stripTrailingNewlines(httpRequest)
+        data.append(13)
         data.append(13)
         data.extend(httpResponse[0:httpResponseBodyOffset])
         data.extend(self.str_to_array(self.CUT_TEXT))
         data.append(13)
-        data.extend(httpResponseData)
+        data.extend(self.stripTrailingNewlines(httpResponseData))
         data.append(13)
         data.extend(self.str_to_array(self.CUT_TEXT))
 

--- a/CopyRequestResponse.py
+++ b/CopyRequestResponse.py
@@ -46,7 +46,9 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         httpRequest = httpTraffic.getRequest()
         httpResponse = httpTraffic.getResponse()
 
-        data = httpRequest + httpResponse
+        data = httpRequest
+        data.append(13) # Line Break
+        data.extend(httpResponse)
 
         self.copyToClipboard(data)
 
@@ -56,7 +58,9 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         httpResponse = httpTraffic.getResponse()
         httpResponseBodyOffset = self.helpers.analyzeResponse(httpResponse).getBodyOffset()
 
-        data = httpRequest + httpResponse[0:httpResponseBodyOffset]
+        data = httpRequest
+        data.append(13)
+        data.extend(httpResponse[0:httpResponseBodyOffset])
         data.extend(self.str_to_array(self.CUT_TEXT))
 
         self.copyToClipboard(data)
@@ -69,9 +73,11 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         selectionBounds = self.context.getSelectionBounds()
         httpResponseData = httpResponse[selectionBounds[0]:selectionBounds[1]]
 
-        data = httpRequest + httpResponse[0:httpResponseBodyOffset]
-        data.append(13) # Line Break
+        data = httpRequest
+        data.append(13)
+        data.extend(httpResponse[0:httpResponseBodyOffset])
         data.extend(self.str_to_array(self.CUT_TEXT))
+        data.append(13)
         data.extend(httpResponseData)
         data.append(13)
         data.extend(self.str_to_array(self.CUT_TEXT))

--- a/CopyRequestResponse.py
+++ b/CopyRequestResponse.py
@@ -99,3 +99,8 @@ class BurpExtender(IBurpExtender, IContextMenuFactory, IHttpRequestResponse):
         transferText = StringSelection(data)
         systemClipboard.setContents(transferText, None)
         systemSelection.setContents(transferText, None)
+
+    def stripTrailingNewlines(self, data):
+        while data[-1] in (10, 13):
+            data = data[:-1]
+        return data


### PR DESCRIPTION
Hi

Then the extension copied requests with a body (everything except a GET request), the newlines between the request and response were missing. This release fixes this issue.

THX for merging.

Best,
Emanuel