### PR TITLE
downgrade api version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ compileJava   {
 }
 
 dependencies {
-    compileOnly 'net.portswigger.burp.extensions:montoya-api:2025.7'
+    compileOnly 'net.portswigger.burp.extensions:montoya-api:2025.6'
 }
 
 jar {


### PR DESCRIPTION
The Montoya API version is used to determine the minimum compatible version of Burp, so ideally this would be the lowest compatible version with your extension code.